### PR TITLE
Add option for 'html' field

### DIFF
--- a/pushover.go
+++ b/pushover.go
@@ -28,7 +28,6 @@ var (
 	ErrInvalidHeaders            = errors.New("pushover: invalid headers in server response")
 	ErrInvalidPriority           = errors.New("pushover: invalid priority")
 	ErrInvalidToken              = errors.New("pushover: invalid API token")
-	ErrInvalidHtml               = errors.New("pushover: invalid HTML value")
 	ErrMessageEmpty              = errors.New("pushover: message empty")
 	ErrMessageTitleTooLong       = errors.New("pushover: message title too long")
 	ErrMessageTooLong            = errors.New("pushover: message too long")
@@ -263,7 +262,7 @@ type Message struct {
 	CallbackURL string
 	DeviceName  string
 	Sound       string
-	Html        int
+	HTML        bool
 }
 
 // NewMessage returns a simple new message
@@ -318,11 +317,6 @@ func (m *Message) validate() error {
 		if m.Retry == 0 || m.Expire == 0 {
 			return ErrMissingEmergencyParameter
 		}
-	}
-
-	// Validate HTML field
-	if m.Html > 1 {
-		return ErrInvalidHtml
 	}
 
 	// Test device name
@@ -381,6 +375,10 @@ func (p *Pushover) encodeRequest(message *Message, recipient *Recipient) (*url.V
 
 	if message.Timestamp != 0 {
 		urlValues.Add("timestamp", strconv.FormatInt(message.Timestamp, 10))
+	}
+
+	if message.HTML {
+		urlValues.Add("html", "1")
 	}
 
 	if message.Priority == PriorityEmergency {

--- a/pushover.go
+++ b/pushover.go
@@ -28,6 +28,7 @@ var (
 	ErrInvalidHeaders            = errors.New("pushover: invalid headers in server response")
 	ErrInvalidPriority           = errors.New("pushover: invalid priority")
 	ErrInvalidToken              = errors.New("pushover: invalid API token")
+	ErrInvalidHtml               = errors.New("pushover: invalid HTML value")
 	ErrMessageEmpty              = errors.New("pushover: message empty")
 	ErrMessageTitleTooLong       = errors.New("pushover: message title too long")
 	ErrMessageTooLong            = errors.New("pushover: message too long")
@@ -262,6 +263,7 @@ type Message struct {
 	CallbackURL string
 	DeviceName  string
 	Sound       string
+	Html        int
 }
 
 // NewMessage returns a simple new message
@@ -316,6 +318,11 @@ func (m *Message) validate() error {
 		if m.Retry == 0 || m.Expire == 0 {
 			return ErrMissingEmergencyParameter
 		}
+	}
+
+	// Validate HTML field
+	if m.Html > 1 {
+		return ErrInvalidHtml
 	}
 
 	// Test device name

--- a/pushover_test.go
+++ b/pushover_test.go
@@ -29,6 +29,7 @@ var fakeMessage = &Message{
 	DeviceName:  "SuperDevice",
 	CallbackURL: "http://yourapp.com/callback",
 	Sound:       SoundCosmic,
+	Html:        1,
 }
 
 func TestValidMessage(t *testing.T) {

--- a/pushover_test.go
+++ b/pushover_test.go
@@ -29,7 +29,7 @@ var fakeMessage = &Message{
 	DeviceName:  "SuperDevice",
 	CallbackURL: "http://yourapp.com/callback",
 	Sound:       SoundCosmic,
-	Html:        1,
+	HTML:        true,
 }
 
 func TestValidMessage(t *testing.T) {
@@ -401,6 +401,7 @@ func TestEncodeRequest(t *testing.T) {
 	expected.Add("device", "SuperDevice")
 	expected.Add("callback", "http://yourapp.com/callback")
 	expected.Add("sound", "cosmic")
+	expected.Add("html", "1")
 
 	// Encode request
 	result, err := fakePushover.encodeRequest(fakeMessage, fakeRecipient)
@@ -632,23 +633,6 @@ func TestSendMessage(t *testing.T) {
 
 	if reflect.DeepEqual(got, expected) == false {
 		t.Errorf("unexpected response from postFrom")
-	}
-}
-
-// TestHtmlMessage tests messages with HTML formatting
-func TestHtmlMessage(t *testing.T) {
-	message := Message{
-		Message: "Test message",
-		Html:    5,
-	}
-
-	err := message.validate()
-	if err == nil {
-		t.Errorf("Message should not be valid with an 'html' value of anything other than 0 or 1")
-	}
-
-	if err != ErrInvalidHtml {
-		t.Errorf("Should get an ErrInvalidHtml")
 	}
 }
 

--- a/pushover_test.go
+++ b/pushover_test.go
@@ -40,7 +40,6 @@ func TestValidMessage(t *testing.T) {
 		URL:        "http://google.com",
 		URLTitle:   "Go check this URL",
 		Priority:   PriorityNormal,
-		Html:       1,
 	}
 
 	err := message.validate()

--- a/pushover_test.go
+++ b/pushover_test.go
@@ -40,6 +40,7 @@ func TestValidMessage(t *testing.T) {
 		URL:        "http://google.com",
 		URLTitle:   "Go check this URL",
 		Priority:   PriorityNormal,
+		Html:       1,
 	}
 
 	err := message.validate()
@@ -631,6 +632,23 @@ func TestSendMessage(t *testing.T) {
 
 	if reflect.DeepEqual(got, expected) == false {
 		t.Errorf("unexpected response from postFrom")
+	}
+}
+
+// TestHtmlMessage tests messages with HTML formatting
+func TestHtmlMessage(t *testing.T) {
+	message := Message{
+		Message: "Test message",
+		Html:    5,
+	}
+
+	err := message.validate()
+	if err == nil {
+		t.Errorf("Message should not be valid with an 'html' value of anything other than 0 or 1")
+	}
+
+	if err != ErrInvalidHtml {
+		t.Errorf("Should get an ErrInvalidHtml")
 	}
 }
 


### PR DESCRIPTION
As per Pushover's API documentation: https://pushover.net/api#html these changes introduce the ability for a user to turn basic HTML formatting on/off in their message.  

I only very recently started learning Go, and programming in general; so please do let me know if there's a nicer/saner way of doing this.

The tests seemed to pass with a supported val for the `html` field, and fail when intentionally set to an invalid value.

Thanks for this great package! :)