### PR TITLE
Fix staticcheck issues

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,7 +1,6 @@
 package pushover
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -12,7 +11,7 @@ type Errors []string
 func (e Errors) Error() string {
 	ret := ""
 	if len(e) > 0 {
-		ret = fmt.Sprintf("Errors:\n")
+		ret = "Errors:\n"
 		ret += strings.Join(e, "\n")
 	}
 	return ret

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,7 +1,6 @@
 package pushover
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -9,7 +8,7 @@ import (
 func TestErrorsString(t *testing.T) {
 	e := &Errors{"error1", "error2"}
 	got := e.Error()
-	expected := fmt.Sprintf("Errors:\nerror1\nerror2")
+	expected := "Errors:\nerror1\nerror2"
 
 	if got != expected {
 		t.Errorf("invalid error string\ngot:\n%s\nexpected:\n%s\n", got, expected)

--- a/helpers.go
+++ b/helpers.go
@@ -38,7 +38,7 @@ func (i *intBool) UnmarshalJSON(data []byte) error {
 	case 1:
 		*i = true
 	default:
-		return fmt.Errorf("Failed to unmarshal int to bool")
+		return fmt.Errorf("failed to unmarshal int to bool")
 	}
 
 	return nil

--- a/message.go
+++ b/message.go
@@ -103,7 +103,7 @@ func (m *Message) validate() error {
 
 	// Test device name
 	if m.DeviceName != "" {
-		if deviceNameRegexp.MatchString(m.DeviceName) == false {
+		if !deviceNameRegexp.MatchString(m.DeviceName) {
 			return ErrInvalidDeviceName
 		}
 	}

--- a/message_test.go
+++ b/message_test.go
@@ -10,7 +10,7 @@ import (
 	"unicode/utf8"
 )
 
-var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789абвгдеёжзийклмнопрстуфхцчшщъыьэюяАБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ😊😂😉😎🎶🐱‍👓")
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789абвгдеёжзийклмнопрстуфхцчшщъыьэюяАБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ😊😂😉😎🎶🐱\u200d👓")
 
 // Returns a random string with a fixed size
 func getRandomString(size int) string {

--- a/pushover.go
+++ b/pushover.go
@@ -109,7 +109,7 @@ func (p *Pushover) validate() error {
 	}
 
 	// Check invalid token
-	if tokenRegexp.MatchString(p.token) == false {
+	if !tokenRegexp.MatchString(p.token) {
 		return ErrInvalidToken
 	}
 	return nil

--- a/recipient.go
+++ b/recipient.go
@@ -26,7 +26,7 @@ func (r *Recipient) validate() error {
 	}
 
 	// Check invalid token
-	if recipientRegexp.MatchString(r.token) == false {
+	if !recipientRegexp.MatchString(r.token) {
 		return ErrInvalidRecipientToken
 	}
 	return nil


### PR DESCRIPTION
Before:
```
$ staticcheck ./...
errors.go:15:9: unnecessary use of fmt.Sprintf (S1039)
errors_test.go:12:14: unnecessary use of fmt.Sprintf (S1039)
helpers.go:41:10: error strings should not be capitalized (ST1005)
message.go:106:6: should omit comparison to bool constant, can be simplified to !deviceNameRegexp.MatchString(m.DeviceName) (S1002)
message_test.go:13:26: string literal contains the Unicode format character U+200D, consider using the '\u200d' escape sequence instead (ST1018)
pushover.go:112:5: should omit comparison to bool constant, can be simplified to !tokenRegexp.MatchString(p.token) (S1002)
recipient.go:29:5: should omit comparison to bool constant, can be simplified to !recipientRegexp.MatchString(r.token) (S1002)
```