### PR TITLE
Delete unused error ErrInvalidRecipient and update comments 

### DIFF
--- a/pushover.go
+++ b/pushover.go
@@ -26,7 +26,6 @@ var (
 	ErrEmptyURL                  = errors.New("pushover: empty URL, URLTitle needs an URL")
 	ErrEmptyRecipientToken       = errors.New("pushover: empty recipient token")
 	ErrInvalidRecipientToken     = errors.New("pushover: invalid recipient token")
-	ErrInvalidRecipient          = errors.New("pushover: invalid recipient")
 	ErrInvalidHeaders            = errors.New("pushover: invalid headers in server response")
 	ErrInvalidPriority           = errors.New("pushover: invalid priority")
 	ErrInvalidToken              = errors.New("pushover: invalid API token")
@@ -161,8 +160,9 @@ func (p *Pushover) GetReceiptDetails(receipt string) (*ReceiptDetails, error) {
 }
 
 // GetRecipientDetails allows to check if a recipient exists, if it's a group
-// and the devices associated to this recipient. It returns an
-// ErrInvalidRecipient if the recipient is not valid in the Pushover API.
+// and the devices associated to this recipient. The Errors field of the
+// RecipientDetails object will contain an error if the recipient is not valid
+// in the Pushover API.
 func (p *Pushover) GetRecipientDetails(recipient *Recipient) (*RecipientDetails, error) {
 	endpoint := fmt.Sprintf("%s/users/validate.json", APIEndpoint)
 

--- a/pushover_test.go
+++ b/pushover_test.go
@@ -144,8 +144,8 @@ func TestPostFormErrors(t *testing.T) {
 	}
 }
 
-// TestGetRecipienDetails
-func TestGetRecipienDetails(t *testing.T) {
+// TestGetRecipientDetails
+func TestGetRecipientDetails(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, `{"status":1,"request":"e460545a8b333d0da2f3602aff3133d6"}`)
 	}))
@@ -170,8 +170,8 @@ func TestGetRecipienDetails(t *testing.T) {
 	}
 }
 
-// TestGetRecipienDetailsError
-func TestGetRecipienDetailsError(t *testing.T) {
+// TestGetRecipientDetailsError
+func TestGetRecipientDetailsError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, `{"status":0,"request":"e460545a8b333d0da2f3602aff3133d6", "errors": ["user key is invalid"]}`)
 	}))


### PR DESCRIPTION
ErrInvalidRecipient should have disappeared on commit 9958d92, if
an error is present, it will be directly returned into the Errors field
of the RecipientDetails object
I updated the comments to match this behaviour