### PR TITLE
Add status to response string

### DIFF
--- a/response.go
+++ b/response.go
@@ -13,7 +13,8 @@ type Response struct {
 
 // String represents a printable form of the response.
 func (r Response) String() string {
-	ret := fmt.Sprintf("Request id: %s\n", r.ID)
+	ret := fmt.Sprintf("Status: %d\n", r.Status)
+	ret += fmt.Sprintf("Request id: %s\n", r.ID)
 	if r.Receipt != "" {
 		ret += fmt.Sprintf("Receipt: %s\n", r.Receipt)
 	}


### PR DESCRIPTION
Simple PR that will add the `status` to the message response string.

Currently this is how the response looks like
```
Request id: 85d89fd6-8fe8-44cd-a783-641be2679916\nUsage 9745/10000 messages\nNext reset : 2023-09-01 07:00:00 +0200 CEST
```
